### PR TITLE
Build Site Navigation

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -24,6 +24,8 @@ jobs:
           cache: npm
       - name: Install packages
         run: npm i
+      - name: Build Site Navigation
+        run: npm run build-site-nav
       - name: Export static files
         run: npm run build
       - name: Add .nojekyll file


### PR DESCRIPTION
This small change adds a step to run the `build-site-nav` script before building the site. 