### PR TITLE
Accessibility: meaningful link text and heading nesting (WCAG)

### DIFF
--- a/components/home/ApplicationTypes.jsx
+++ b/components/home/ApplicationTypes.jsx
@@ -9,16 +9,19 @@ export default function ApplicationTypes({ applicationTypes = [] }) {
     <div className="py-24 bg-samGreyDark sm:py-32">
       <div className="px-6 mx-auto max-w-7xl lg:px-8">
         <FadeIn className="max-w-2xl mx-auto lg:text-center">
-          <h2
-            id="applications"
-            className="text-base font-semibold leading-7 text-samBlue"
+          <span
+            className="block text-base font-semibold leading-7 text-samBlue"
+            aria-hidden="true"
           >
             Applications
-          </h2>
-          <p className="mt-2 text-3xl font-bold tracking-tight text-white sm:text-4xl">
+          </span>
+          <h2
+            id="applications"
+            className="mt-2 text-3xl font-bold tracking-tight text-white sm:text-4xl"
+          >
             Types of Applications powered by Samvera Community technology
             solutions
-          </p>
+          </h2>
         </FadeIn>
         <div className="max-w-2xl mx-auto mt-16 sm:mt-20 lg:mt-24 lg:max-w-none">
           <dl className="grid max-w-xl grid-cols-1 gap-x-8 gap-y-16 lg:max-w-none lg:grid-cols-3">
@@ -39,19 +42,19 @@ export default function ApplicationTypes({ applicationTypes = [] }) {
                     <div className="flex-auto [&_a]:text-samBlue">
                       <RichTextContent content={description.content[0]} />
                     </div>
-                    <p className="mt-6">
-                      <Link
-                        href={`/types-of-applications`}
-                        className="text-sm font-semibold leading-6 text-samBlue"
-                      >
-                        Learn more <span aria-hidden="true">→</span>
-                      </Link>
-                    </p>
                   </dd>
                 </FadeIn>
               );
             })}
           </dl>
+        </div>
+        <div className="flex justify-center mt-12">
+          <Link
+            href="/types-of-applications"
+            className="button"
+          >
+            View applications powered by Samvera
+          </Link>
         </div>
       </div>
     </div>

--- a/components/home/Applications.jsx
+++ b/components/home/Applications.jsx
@@ -89,7 +89,7 @@ export default function Applications() {
             collaboration to extend the existing Samvera project codebase to
             build, bundle, and promote a feature-rich, robust, flexible digital
             repository that is easy to install, configure, and maintain. &nbsp;
-            <a href="https://hyku.samvera.org/">Learn more</a>
+            <a href="https://hyku.samvera.org/">See Hyku, the Samvera digital repository</a>
           </p>
         </>
       ),

--- a/components/home/Community.jsx
+++ b/components/home/Community.jsx
@@ -24,7 +24,7 @@ export default function Community() {
 
           <div className="flex items-center justify-center mt-10 gap-x-6">
             <Link href="/getting-started" className="button">
-              Get started
+              Get started with repository solutions
             </Link>
           </div>
         </div>

--- a/components/home/Hero.jsx
+++ b/components/home/Hero.jsx
@@ -25,12 +25,12 @@ export default function HomeHero() {
           <div className="mt-10 sm:flex sm:justify-center lg:justify-start">
             <div className="rounded-md shadow">
               <Link className="button" href="/get-started/getting-started">
-                Get started
+                Get started with repository solutions
               </Link>
             </div>
             <div className="mt-3 rounded-md shadow sm:mt-0 sm:ml-3">
               <a className="button-inverted" href="#applications">
-                Learn More About Samvera
+                See Samvera applications
               </a>
             </div>
           </div>

--- a/components/news/BlogPostsWithFeatured.jsx
+++ b/components/news/BlogPostsWithFeatured.jsx
@@ -43,7 +43,7 @@ export default function BlogPostsWithFeatured({ blogPosts = [] }) {
                 className="text-sm font-semibold leading-6"
                 aria-describedby="featured-post"
               >
-                Continue reading <span aria-hidden="true">&rarr;</span>
+                Read the full post <span aria-hidden="true">&rarr;</span>
               </a>
             </div>
             <div className="flex lg:border-t lg:border-gray-900/10 lg:pt-8">


### PR DESCRIPTION
## Summary
Implements accessibility improvements for button/link language and heading structure per WCAG guidance on [Writing Meaningful Link Text](https://www.w3.org/WAI/WCAG21/Understanding/link-purpose-in-context.html).

Fixes: #134 

## Changes

### First section (Hero & Community)
- **Get started** → **Get started with repository solutions**
- **Learn more** → **See Samvera applications** (Hero CTA linking to #applications)
- Community CTA updated to **Get started with repository solutions**

### Second section (News / blog)
- **Continue reading** → **Read the full post**

### Third section (Applications / Types of Applications)
- Removed repeated “Learn more” links from each application-type card (all pointed to the same page).
- Added a single primary CTA: **View applications powered by Samvera** (links to `/types-of-applications`).
- In the Applications slides (Hyku): **Learn more** → **See Hyku, the Samvera digital repository**.

### Heading nesting
- Applications section: “Applications” is now a visual label (span); the main section title “Types of Applications powered by Samvera Community technology solutions” is the single `<h2>` with `id="applications"` for correct outline and anchor.